### PR TITLE
add link to github repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   },
   "keywords": [],
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/newfrgmnt/harmony"
+  },
   "license": "MIT",
   "devDependencies": {
     "@types/react": "^18.2.47",


### PR DESCRIPTION
add link so that we can find the github repository in npm package page https://www.npmjs.com/package/@newfrgmnt/harmony