### PR TITLE
fix: incorrect package.json main/module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@newfrgmnt/harmony",
   "version": "1.0.2",
-  "main": "./build/index.js",
-  "module": "./build/index.mjs",
+  "main": "./build/index.cjs",
+  "module": "./build/index.js",
   "types": "./build/index.d.ts",
   "files": [
     "build/*"


### PR DESCRIPTION
This project look so cool!

When I build with vite, it occurs the error

```bash
[commonjs--resolver] Failed to resolve entry for package "@newfrgmnt/harmony". The package may have incorrect main/module/exports specified in its package.json.
error during build:
Error: Failed to resolve entry for package "@newfrgmnt/harmony". The package may have incorrect main/module/exports specified in its package.json.
```

The package.json is
```json
{
  "name": "@newfrgmnt/harmony",
  "version": "1.0.2",
  "main": "./build/index.js",
  "module": "./build/index.mjs",
  "types": "./build/index.d.ts",
}
```

but build dir are
```bash
@newfrgmnt/harmony/build
├── index.cjs
├── index.d.cts
├── index.d.ts
└── index.js

1 directory, 4 files
```

Thus I modify the package.json main/module to correct file.
